### PR TITLE
Default assets paths don't work on Sinatra::AssetPack. It needs to be relative.

### DIFF
--- a/lib/padrino-pipeline/pipelines/asset_pack.rb
+++ b/lib/padrino-pipeline/pipelines/asset_pack.rb
@@ -29,10 +29,10 @@ module Padrino
 
         @app.assets {
           def mount_asset(prefix, assets)
-            if assets.respond_to?(:each)
-              assets.each {|asset| serve prefix, :from => asset} 
-            else
-              serve prefix, :from => assets
+            # AssetPack needs assets path to be relative
+            [*assets].each do |asset|
+              asset.slice!("#{@app.root}/") if asset.start_with?("#{@app.root}/")
+              serve prefix, :from => asset
             end
           end
 

--- a/test/asset_pack/test_packages.rb
+++ b/test/asset_pack/test_packages.rb
@@ -17,6 +17,21 @@ describe 'AssetPack Packages' do
       assert_equal 200, last_response.status
     end
 
+    it 'can serve an version-cached asset pack' do
+      app_root = fixture_path('asset_pack_app')
+      mock_app do
+        set :root, app_root
+        register Padrino::Pipeline
+        configure_assets do |config|
+          config.pipeline   = Padrino::Pipeline::AssetPack
+          config.packages << [:js, :application, '/assets/javascripts/application.js', ['/assets/javascripts/*.js']]
+        end
+        get('/helper/js') { js :application }
+      end
+      get '/helper/js'
+      assert_match %r{\/assets\/javascripts\/\w+\.\w+\.js}, last_response.body
+    end
+
     it 'can serve an asset pack from a non-standard location' do
       mock_app do
         register Padrino::Pipeline


### PR DESCRIPTION
The default assets paths are absolute:

``` ruby
@image_assets = "#{app_root}/assets/images"
@js_assets    = "#{app_root}/assets/javascripts"
@css_assets   = "#{app_root}/assets/stylesheets"
```

They are not compatible with Sinatra::AssetPack. The line 252 and line3 of sinatra-assetpack/lib/sinatra/assetpack/options.rb shows:

``` ruby
tuples = @served.map { |prefix, local_path|
          path = File.expand_path(File.join(@app.root, local_path))
          ...
```

Take js assets for example. @app.root is "/path/to/padrino/root/app", and local_path is just what we defined of @js_assets, which is "/path/to/padrino/root/app/assets/javascripts'. Pay attention to that join method calling. So path variable will be a mess: "/path/to/padrino/root/app/path/to/padrino/root/app/assets/javascripts". That stops AssetPack from working.
