### PR TITLE
Allow for newer versions of Gems in depencies

### DIFF
--- a/padrino-pipeline.gemspec
+++ b/padrino-pipeline.gemspec
@@ -23,12 +23,12 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rdoc_options  = ["--charset=UTF-8"]
 
-  s.add_dependency("padrino-core", "~> 0.11.0")
-  s.add_dependency("padrino-helpers", "~> 0.11.0")
+  s.add_dependency("padrino-core", "~> 0.11")
+  s.add_dependency("padrino-helpers", "~> 0.11")
   s.add_dependency("coffee-script", "~> 2.2.0")
   s.add_dependency("sass", "~> 3.2.0")
-  s.add_dependency("sprockets", "~> 2.10.0")
   s.add_dependency("uglifier", "~> 2.1.0")
-
+  
+  s.add_dependency("sprockets", "~> 2.10.0")
   s.add_dependency("sinatra-assetpack", "~> 0.3.0")
 end

--- a/padrino-pipeline.gemspec
+++ b/padrino-pipeline.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
   s.add_dependency("sass", "~> 3.2.0")
   s.add_dependency("uglifier", "~> 2.1.0")
   
-  s.add_dependency("sprockets", "~> 2.10.0")
-  s.add_dependency("sinatra-assetpack", "~> 0.3.0")
+  s.add_dependency("sprockets", "~> 2.10")
+  s.add_dependency("sinatra-assetpack", "~> 0.3")
 end


### PR DESCRIPTION
Padrino 0.12 is coming out soon, and newer versions of sinatra-assetpack and sprockets are out.
