### PR TITLE
Allow versions of padrino greater 0.11.*

### DIFF
--- a/padrino-pipeline.gemspec
+++ b/padrino-pipeline.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rdoc_options  = ["--charset=UTF-8"]
 
-  s.add_dependency("padrino-core", "~> 0.11")
-  s.add_dependency("padrino-helpers", "~> 0.11")
+  s.add_dependency("padrino-core", ">= 0.11")
+  s.add_dependency("padrino-helpers", ">= 0.11")
   s.add_dependency("coffee-script", "~> 2.2.0")
   s.add_dependency("sass", "~> 3.2.0")
   s.add_dependency("uglifier", "~> 2.1.0")


### PR DESCRIPTION
Fixes #16. http://robots.thoughtbot.com/rubys-pessimistic-operator describes the pros and cons of this.
