### PR TITLE
clean dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,2 @@
 source 'https://rubygems.org'
-
 gemspec 
-gem "rake"
-(RUBY_VERSION < "1.9") ? gem("nokogiri",  "~> 1.5.10") : gem("nokogiri",  "~> 1.6")
-
-group :test do
-  gem "rack-test", ">= 0.5.0"
-  gem "minitest",  "~> 4.0"
-  gem "bootstrap-sass", "~> 3.1"
-end

--- a/lib/padrino-pipeline/pipelines/asset_pack.rb
+++ b/lib/padrino-pipeline/pipelines/asset_pack.rb
@@ -15,8 +15,13 @@ module Padrino
       end
 
       private
+
       def require_libraries
         require 'sinatra/assetpack'
+      rescue LoadError
+        message = 'Please, add `gem "sinatra-assetpack", "~> 0.3"` to your app Gemfile'
+        defined?(logger) ? logger.error(message) : warn(message)
+        raise
       end
 
       def setup_enviroment

--- a/lib/padrino-pipeline/pipelines/sprockets.rb
+++ b/lib/padrino-pipeline/pipelines/sprockets.rb
@@ -11,8 +11,17 @@ module Padrino
       end
 
       private
+
+      REQUIRED_LIBRARIES = %w[sprockets uglifier]
+
       def require_libraries
-        %w[sprockets uglifier].each { |package| require package }
+        REQUIRED_LIBRARIES.each { |package| require package }
+      rescue LoadError
+        message = REQUIRED_LIBRARIES.inject("Please, add these to your app Gemfile:\n") do |all, package|
+          all << "gem '#{package}'\n"
+        end
+        defined?(logger) ? logger.error(message) : warn(message)
+        raise
       end
 
       def paths

--- a/padrino-pipeline.gemspec
+++ b/padrino-pipeline.gemspec
@@ -23,12 +23,21 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rdoc_options  = ["--charset=UTF-8"]
 
+
   s.add_dependency("padrino-core", ">= 0.11")
   s.add_dependency("padrino-helpers", ">= 0.11")
-  s.add_dependency("coffee-script", "~> 2.2")
-  s.add_dependency("sass", "~> 3.0")
-  s.add_dependency("uglifier", "~> 2.1")
+
+  s.add_development_dependency("nokogiri", RUBY_VERSION < "1.9" ? "~> 1.5.10" : "~> 1.6")
+
+  s.add_development_dependency("rake")
+  s.add_development_dependency("rack-test", ">= 0.5.0")
+  s.add_development_dependency("minitest")
+  s.add_development_dependency("bootstrap-sass", "~> 3.1")
+
+  s.add_development_dependency("coffee-script", "~> 2.2")
+  s.add_development_dependency("sass", "~> 3.0")
+  s.add_development_dependency("uglifier", "~> 2.1")
   
-  s.add_dependency("sprockets", "~> 2.11")
-  s.add_dependency("sinatra-assetpack", "~> 0.3")
+  s.add_development_dependency("sprockets", "~> 2.11")
+  s.add_development_dependency("sinatra-assetpack", "~> 0.3")
 end


### PR DESCRIPTION
Heavy pipeline dependencies should be moved to application `Gemfile`. Now any application bundling with `padrino-pipeline` gets dependent on all the engines supported by `padrino-pipeline`. This PR fixes it.
